### PR TITLE
Add docker compose instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ cd bracket
 sudo docker-compose up -d
 ```
 
-This will start the backend and frontend of Bracket, as well as a postgres instance.
-Please only use this for testing/development purposes.
+This will start the backend and frontend of Bracket, as well as a postgres instance. You should now
+be able to view bracket at http://localhost:3000.
 
 To insert dummy rows into the database, run:
 ```shell

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Bracket is written in async Python (with [FastAPI](https://fastapi.tiangolo.com)
 
 # Quickstart
 To quickly run bracket to see how it works, clone it and run `docker-compose up`:
-```
+```shell
 git clone git@github.com:evroon/bracket.git
 cd bracket
 sudo docker-compose up -d
@@ -30,6 +30,11 @@ sudo docker-compose up -d
 
 This will start the backend and frontend of Bracket, as well as a postgres instance.
 Please only use this for testing/development purposes.
+
+To insert dummy rows into the database, run:
+```shell
+sudo docker exec -it bracket-backend pipenv run ./cli.py create-dev-db
+```
 
 # Setup
 ## Database

--- a/README.md
+++ b/README.md
@@ -20,9 +20,18 @@ Bracket is written in async Python (with FastAPI) and Next.js as frontend using 
 <img alt="" src="misc/img/schedule_preview.png" width="100%" />
 <img alt="" src="misc/img/players_preview.png" width="100%" />
 
+# Quickstart
+To quickly run bracket to see how it works, clone it and run `docker-compose up`:
+```
+git clone git@github.com:evroon/bracket.git
+cd bracket
+sudo docker-compose up -d
+```
+
+This will start the backend and frontend of Bracket, as well as a postgres instance.
+Please only use this for testing/development purposes.
+
 # Setup
-
-
 ## Database
 First create a `bracket` cluster:
 ```shell

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 > Release v1.0.0 will be the first out-of-beta release.
 
 Ladder tournament system meant to be easy to use.
-Bracket is written in async Python (with FastAPI) and Next.js as frontend using the [Mantine](https://mantine.dev/) library.
+Bracket is written in async Python (with [FastAPI](https://fastapi.tiangolo.com)) and Next.js as frontend using the [Mantine](https://mantine.dev/) library.
 
 
 ### Preview

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ be able to view bracket at http://localhost:3000.
 
 To insert dummy rows into the database, run:
 ```shell
-sudo docker exec -it bracket-backend pipenv run ./cli.py create-dev-db
+sudo docker exec bracket-backend pipenv run ./cli.py create-dev-db
 ```
 
 # Setup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,14 @@ version: '3.1'
 
 services:
     bracket-frontend:
-        build: frontend
+        image: ghcr.io/evroon/bracket-frontend
         container_name: bracket-frontend
         ports:
             - "3000:3000"
         restart: unless-stopped
 
     bracket-backend:
-        build: backend
+        image: ghcr.io/evroon/bracket-backend
         container_name: bracket-backend
         ports:
             - "8400:8400"


### PR DESCRIPTION
Adds a quickstart section to README explaining how to run Bracket with docker-compose.

See https://github.com/evroon/bracket/issues/197