### PR TITLE
Revert "Bump codecov/codecov-action from 3 to 4 (#268)"

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -40,7 +40,7 @@ jobs:
           ENVIRONMENT: CI
 
       - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
 
       - name: Run mypy
         run: pipenv run mypy --version && pipenv run mypy .


### PR DESCRIPTION
This reverts commit 3b99b5940f0c2645494605c12aa000b34f28292b.

stable release doesn't exist yet