### PR TITLE
Make cors middleware disabled by default

### DIFF
--- a/backend/bracket/config.py
+++ b/backend/bracket/config.py
@@ -30,7 +30,7 @@ class Config(BaseSettings):
     allow_user_registration: bool = True
     base_url: str = 'http://localhost:8400'
     cors_origin_regex: str = ''
-    cors_origins: str = ''
+    cors_origins: str = '*'
     jwt_secret: str
     pg_dsn: PostgresDsn = 'postgresql://user:pass@localhost:5432/db'  # type: ignore[assignment]
     sentry_dsn: str | None = None

--- a/backend/ci.env
+++ b/backend/ci.env
@@ -1,5 +1,5 @@
 PG_DSN='postgresql://bracket_ci:bracket_ci@localhost:5532/bracket_ci'
 JWT_SECRET='abd84ebeb6581c26b53fa30d89c4e7fbc48ee5b4f3b8ddedb7586cfeb3daca0c'
-CORS_ORIGINS=''
+CORS_ORIGINS='*'
 ADMIN_EMAIL='admin@example.com'
 ADMIN_PASSWORD='some unused password'


### PR DESCRIPTION
In development, CORS isn't really useful to enable.
I added a warning in production if the `CORS_ORIGINS` env var is set to `*` (the default).