### PR TITLE
Fix dashboard link unique bug

### DIFF
--- a/backend/bracket/models/db/tournament.py
+++ b/backend/bracket/models/db/tournament.py
@@ -2,6 +2,7 @@ from heliclockter import datetime_utc
 from pydantic import Field
 
 from bracket.models.db.shared import BaseModelORM
+from bracket.utils.pydantic import EmptyStrToNone
 
 
 class Tournament(BaseModelORM):
@@ -23,7 +24,7 @@ class TournamentUpdateBody(BaseModelORM):
     start_time: datetime_utc
     name: str
     dashboard_public: bool
-    dashboard_endpoint: str | None = None
+    dashboard_endpoint: EmptyStrToNone | str = None
     players_can_be_in_multiple_teams: bool
     auto_assign_courts: bool
     duration_minutes: int = Field(..., ge=1)

--- a/backend/bracket/utils/pydantic.py
+++ b/backend/bracket/utils/pydantic.py
@@ -1,0 +1,13 @@
+from typing import Annotated
+
+from pydantic import PlainValidator
+
+
+def accept_none_and_empty_str(value: str | None) -> None:
+    if value is None or value == "":
+        return None
+
+    raise ValueError("Not an empty str or None")
+
+
+EmptyStrToNone = Annotated[None, PlainValidator(accept_none_and_empty_str)]


### PR DESCRIPTION
The frontend will send `"dashboard_link": ""` (empty string) but it should be converted to `None` instead. Otherwise tournaments quickly have non-unique endpoints.