### PR TITLE
Check foreign keys belong to tournament

### DIFF
--- a/backend/bracket/routes/matches.py
+++ b/backend/bracket/routes/matches.py
@@ -26,7 +26,7 @@ from bracket.routes.util import match_dependency, round_dependency, round_with_m
 from bracket.sql.courts import get_all_courts_in_tournament
 from bracket.sql.matches import sql_create_match, sql_delete_match, sql_update_match
 from bracket.sql.tournaments import sql_get_tournament
-from bracket.sql.validation import check_inputs_belong_to_tournament
+from bracket.sql.validation import check_foreign_keys_belong_to_tournament
 from bracket.utils.id_types import MatchId, TournamentId
 from bracket.utils.types import assert_some
 
@@ -78,7 +78,7 @@ async def create_match(
     match_body: MatchCreateBodyFrontend,
     _: UserPublic = Depends(user_authenticated_for_tournament),
 ) -> SingleMatchResponse:
-    await check_inputs_belong_to_tournament(match_body, tournament_id)
+    await check_foreign_keys_belong_to_tournament(match_body, tournament_id)
 
     tournament = await sql_get_tournament(tournament_id)
     body_with_durations = MatchCreateBody(
@@ -108,7 +108,7 @@ async def reschedule_match(
     body: MatchRescheduleBody,
     _: UserPublic = Depends(user_authenticated_for_tournament),
 ) -> SuccessResponse:
-    await check_inputs_belong_to_tournament(body, tournament_id)
+    await check_foreign_keys_belong_to_tournament(body, tournament_id)
     await handle_match_reschedule(tournament_id, body, match_id)
     return SuccessResponse()
 
@@ -179,7 +179,7 @@ async def update_match_by_id(
     _: UserPublic = Depends(user_authenticated_for_tournament),
     match: Match = Depends(match_dependency),
 ) -> SuccessResponse:
-    await check_inputs_belong_to_tournament(match_body, tournament_id)
+    await check_foreign_keys_belong_to_tournament(match_body, tournament_id)
     tournament = await sql_get_tournament(tournament_id)
 
     await sql_update_match(assert_some(match.id), match_body, tournament)

--- a/backend/bracket/routes/matches.py
+++ b/backend/bracket/routes/matches.py
@@ -26,6 +26,7 @@ from bracket.routes.util import match_dependency, round_dependency, round_with_m
 from bracket.sql.courts import get_all_courts_in_tournament
 from bracket.sql.matches import sql_create_match, sql_delete_match, sql_update_match
 from bracket.sql.tournaments import sql_get_tournament
+from bracket.sql.validation import check_inputs_belong_to_tournament
 from bracket.utils.id_types import MatchId, TournamentId
 from bracket.utils.types import assert_some
 
@@ -77,6 +78,8 @@ async def create_match(
     match_body: MatchCreateBodyFrontend,
     _: UserPublic = Depends(user_authenticated_for_tournament),
 ) -> SingleMatchResponse:
+    await check_inputs_belong_to_tournament(match_body, tournament_id)
+
     tournament = await sql_get_tournament(tournament_id)
     body_with_durations = MatchCreateBody(
         **match_body.model_dump(),
@@ -105,6 +108,7 @@ async def reschedule_match(
     body: MatchRescheduleBody,
     _: UserPublic = Depends(user_authenticated_for_tournament),
 ) -> SuccessResponse:
+    await check_inputs_belong_to_tournament(body, tournament_id)
     await handle_match_reschedule(tournament_id, body, match_id)
     return SuccessResponse()
 
@@ -175,9 +179,9 @@ async def update_match_by_id(
     _: UserPublic = Depends(user_authenticated_for_tournament),
     match: Match = Depends(match_dependency),
 ) -> SuccessResponse:
-    assert match.id
+    await check_inputs_belong_to_tournament(match_body, tournament_id)
     tournament = await sql_get_tournament(tournament_id)
 
-    await sql_update_match(match.id, match_body, tournament)
+    await sql_update_match(assert_some(match.id), match_body, tournament)
     await recalculate_ranking_for_tournament_id(tournament_id)
     return SuccessResponse()

--- a/backend/bracket/routes/rounds.py
+++ b/backend/bracket/routes/rounds.py
@@ -22,6 +22,7 @@ from bracket.schema import rounds
 from bracket.sql.rounds import get_next_round_name, set_round_active_or_draft, sql_create_round
 from bracket.sql.stage_items import get_stage_item
 from bracket.sql.stages import get_full_tournament_details
+from bracket.sql.validation import check_inputs_belong_to_tournament
 from bracket.utils.id_types import RoundId, TournamentId
 
 router = APIRouter()
@@ -55,6 +56,8 @@ async def create_round(
     round_body: RoundCreateBody,
     user: UserPublic = Depends(user_authenticated_for_tournament),
 ) -> SuccessResponse:
+    await check_inputs_belong_to_tournament(round_body, tournament_id)
+
     stages = await get_full_tournament_details(tournament_id)
     existing_rounds = [
         round_

--- a/backend/bracket/routes/rounds.py
+++ b/backend/bracket/routes/rounds.py
@@ -22,7 +22,7 @@ from bracket.schema import rounds
 from bracket.sql.rounds import get_next_round_name, set_round_active_or_draft, sql_create_round
 from bracket.sql.stage_items import get_stage_item
 from bracket.sql.stages import get_full_tournament_details
-from bracket.sql.validation import check_inputs_belong_to_tournament
+from bracket.sql.validation import check_foreign_keys_belong_to_tournament
 from bracket.utils.id_types import RoundId, TournamentId
 
 router = APIRouter()
@@ -56,7 +56,7 @@ async def create_round(
     round_body: RoundCreateBody,
     user: UserPublic = Depends(user_authenticated_for_tournament),
 ) -> SuccessResponse:
-    await check_inputs_belong_to_tournament(round_body, tournament_id)
+    await check_foreign_keys_belong_to_tournament(round_body, tournament_id)
 
     stages = await get_full_tournament_details(tournament_id)
     existing_rounds = [

--- a/backend/bracket/routes/stage_items.py
+++ b/backend/bracket/routes/stage_items.py
@@ -31,7 +31,7 @@ from bracket.sql.stage_items import (
     sql_create_stage_item,
 )
 from bracket.sql.stages import get_full_tournament_details
-from bracket.sql.validation import check_inputs_belong_to_tournament
+from bracket.sql.validation import check_foreign_keys_belong_to_tournament
 from bracket.utils.id_types import StageItemId, TournamentId
 
 router = APIRouter()
@@ -63,7 +63,7 @@ async def create_stage_item(
             detail="Team count doesn't match number of inputs",
         )
 
-    await check_inputs_belong_to_tournament(stage_body, tournament_id)
+    await check_foreign_keys_belong_to_tournament(stage_body, tournament_id)
 
     stages = await get_full_tournament_details(tournament_id)
     existing_stage_items = [stage_item for stage in stages for stage_item in stage.stage_items]

--- a/backend/bracket/routes/stage_items.py
+++ b/backend/bracket/routes/stage_items.py
@@ -31,6 +31,7 @@ from bracket.sql.stage_items import (
     sql_create_stage_item,
 )
 from bracket.sql.stages import get_full_tournament_details
+from bracket.sql.validation import check_inputs_belong_to_tournament
 from bracket.utils.id_types import StageItemId, TournamentId
 
 router = APIRouter()
@@ -61,6 +62,8 @@ async def create_stage_item(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Team count doesn't match number of inputs",
         )
+
+    await check_inputs_belong_to_tournament(stage_body, tournament_id)
 
     stages = await get_full_tournament_details(tournament_id)
     existing_stage_items = [stage_item for stage in stages for stage_item in stage.stage_items]

--- a/backend/bracket/routes/teams.py
+++ b/backend/bracket/routes/teams.py
@@ -26,6 +26,7 @@ from bracket.sql.teams import (
     get_teams_with_members,
     sql_delete_team,
 )
+from bracket.sql.validation import check_inputs_belong_to_tournament
 from bracket.utils.db import fetch_one_parsed
 from bracket.utils.id_types import PlayerId, TeamId, TournamentId
 from bracket.utils.pagination import PaginationTeams
@@ -78,6 +79,8 @@ async def update_team_by_id(
     _: UserPublic = Depends(user_authenticated_for_tournament),
     team: Team = Depends(team_dependency),
 ) -> SingleTeamResponse:
+    await check_inputs_belong_to_tournament(team_body, tournament_id)
+
     await database.execute(
         query=teams.update().where(
             (teams.c.id == team.id) & (teams.c.tournament_id == tournament_id)
@@ -133,6 +136,8 @@ async def create_team(
     tournament_id: TournamentId,
     user: UserPublic = Depends(user_authenticated_for_tournament),
 ) -> SingleTeamResponse:
+    await check_inputs_belong_to_tournament(team_to_insert, tournament_id)
+
     existing_teams = await get_teams_with_members(tournament_id)
     check_requirement(existing_teams, user, "max_teams")
 

--- a/backend/bracket/routes/teams.py
+++ b/backend/bracket/routes/teams.py
@@ -26,7 +26,7 @@ from bracket.sql.teams import (
     get_teams_with_members,
     sql_delete_team,
 )
-from bracket.sql.validation import check_inputs_belong_to_tournament
+from bracket.sql.validation import check_foreign_keys_belong_to_tournament
 from bracket.utils.db import fetch_one_parsed
 from bracket.utils.id_types import PlayerId, TeamId, TournamentId
 from bracket.utils.pagination import PaginationTeams
@@ -79,7 +79,7 @@ async def update_team_by_id(
     _: UserPublic = Depends(user_authenticated_for_tournament),
     team: Team = Depends(team_dependency),
 ) -> SingleTeamResponse:
-    await check_inputs_belong_to_tournament(team_body, tournament_id)
+    await check_foreign_keys_belong_to_tournament(team_body, tournament_id)
 
     await database.execute(
         query=teams.update().where(
@@ -136,7 +136,7 @@ async def create_team(
     tournament_id: TournamentId,
     user: UserPublic = Depends(user_authenticated_for_tournament),
 ) -> SingleTeamResponse:
-    await check_inputs_belong_to_tournament(team_to_insert, tournament_id)
+    await check_foreign_keys_belong_to_tournament(team_to_insert, tournament_id)
 
     existing_teams = await get_teams_with_members(tournament_id)
     check_requirement(existing_teams, user, "max_teams")

--- a/backend/bracket/routes/users.py
+++ b/backend/bracket/routes/users.py
@@ -51,7 +51,7 @@ async def get_me(
 
 
 @router.put("/users/{user_id}", response_model=UserPublicResponse)
-async def put_user(
+async def update_user_details(
     user_id: UserId,
     user_to_update: UserToUpdate,
     user_public: UserPublic = Depends(user_authenticated),

--- a/backend/bracket/sql/players.py
+++ b/backend/bracket/sql/players.py
@@ -49,6 +49,19 @@ async def get_all_players_in_tournament(
     return [Player.model_validate(x) for x in result]
 
 
+async def get_player_by_id(player_id: PlayerId, tournament_id: TournamentId) -> Player | None:
+    query = """
+        SELECT *
+        FROM players
+        WHERE id = :player_id
+        AND tournament_id = :tournament_id
+    """
+    result = await database.fetch_one(
+        query=query, values={"player_id": player_id, "tournament_id": tournament_id}
+    )
+    return Player.model_validate(result) if result is not None else None
+
+
 async def get_player_count(
     tournament_id: TournamentId,
     *,

--- a/backend/bracket/sql/stage_items.py
+++ b/backend/bracket/sql/stage_items.py
@@ -52,13 +52,3 @@ async def get_stage_item(
         return None
 
     return stages[0].stage_items[0]
-
-
-async def get_stage_items(
-    tournament_id: TournamentId, stage_item_ids: set[StageItemId]
-) -> list[StageItemWithRounds]:
-    stages = await get_full_tournament_details(tournament_id, stage_item_ids=stage_item_ids)
-    if len(stages) < 1:
-        return []
-
-    return stages[0].stage_items

--- a/backend/bracket/sql/validation.py
+++ b/backend/bracket/sql/validation.py
@@ -99,7 +99,7 @@ async def check_court_belongs_to_tournament(
     return any(court_id == court.id for court in await get_all_courts_in_tournament(tournament_id))
 
 
-async def check_inputs_belong_to_tournament(
+async def check_foreign_keys_belong_to_tournament(
     some_body: BaseModel, tournament_id: TournamentId
 ) -> None:
     stages = await get_full_tournament_details(tournament_id)
@@ -119,7 +119,7 @@ async def check_inputs_belong_to_tournament(
         field_value = getattr(some_body, field_key)
 
         if isinstance(field_value, BaseModel):
-            await check_inputs_belong_to_tournament(field_value, tournament_id)
+            await check_foreign_keys_belong_to_tournament(field_value, tournament_id)
         elif isinstance(field_value, set):
             if field_info.annotation == set[PlayerId]:
                 await check_players_belong_to_tournament(field_value, tournament_id)

--- a/backend/bracket/sql/validation.py
+++ b/backend/bracket/sql/validation.py
@@ -99,8 +99,8 @@ async def check_court_belongs_to_tournament(
     return any(court_id == court.id for court in await get_all_courts_in_tournament(tournament_id))
 
 
-def raise_exception(possible_type: Any, field_value: Any) -> NoReturn:
-    field_name = possible_type.__name__ if possible_type is not None else "Unknown type"
+def raise_exception(field_type: Any, field_value: Any) -> NoReturn:
+    field_name = field_type.__name__ if field_type is not None else "Unknown type"
     msg = f"Could not find {field_name.replace('Id', '')}(s) with ID {field_value}"
     raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=msg)
 

--- a/backend/bracket/sql/validation.py
+++ b/backend/bracket/sql/validation.py
@@ -102,6 +102,11 @@ async def check_court_belongs_to_tournament(
 async def check_foreign_keys_belong_to_tournament(
     some_body: BaseModel, tournament_id: TournamentId
 ) -> None:
+    """
+    Inspects the types of BaseModel attributes, and based on that checks whether that attribute
+    is indeed part of the tournament. This prohibits e.g. adding players from another tournament to
+    a certain team.
+    """
     stages = await get_full_tournament_details(tournament_id)
 
     check_lookup: dict[type[Any], CheckCallableT] = {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -51,8 +51,12 @@ ignore_missing_imports = true
 
 [tool.pylint.'MESSAGES CONTROL']
 disable = [
+    'broad-except',
+    'broad-exception-raised',
+    'consider-iterating-dictionary',
     'dangerous-default-value',
     'duplicate-code',
+    'fixme',
     'import-outside-toplevel',
     'invalid-name',
     'logging-fstring-interpolation',
@@ -66,9 +70,6 @@ disable = [
     'unspecified-encoding',
     'unused-argument',  # Gives false positives.
     'wrong-import-position',
-    'fixme',
-    'broad-except',
-    'consider-iterating-dictionary',
 ]
 
 [tool.bandit]

--- a/backend/tests/integration_tests/api/teams_test.py
+++ b/backend/tests/integration_tests/api/teams_test.py
@@ -101,4 +101,4 @@ async def test_update_team_invalid_players(
         response = await send_tournament_request(
             HTTPMethod.PUT, f"teams/{team_inserted.id}", auth_context, None, body
         )
-        assert response == "Could not find Player(s) with ID {-1}"
+        assert response == {'detail': 'Could not find Player(s) with ID {-1}'}

--- a/backend/tests/integration_tests/api/teams_test.py
+++ b/backend/tests/integration_tests/api/teams_test.py
@@ -89,3 +89,16 @@ async def test_update_team(
         assert response["data"]["name"] == body["name"]
 
         await assert_row_count_and_clear(teams, 1)
+
+
+async def test_update_team_invalid_players(
+    startup_and_shutdown_uvicorn_server: None, auth_context: AuthContext
+) -> None:
+    body = {"name": "Some new name", "active": True, "player_ids": [-1]}
+    async with inserted_team(
+        DUMMY_TEAM1.model_copy(update={"tournament_id": auth_context.tournament.id})
+    ) as team_inserted:
+        response = await send_tournament_request(
+            HTTPMethod.PUT, f"teams/{team_inserted.id}", auth_context, None, body
+        )
+        assert response == "Could not find Player(s) with ID {-1}"

--- a/backend/tests/integration_tests/api/teams_test.py
+++ b/backend/tests/integration_tests/api/teams_test.py
@@ -101,4 +101,4 @@ async def test_update_team_invalid_players(
         response = await send_tournament_request(
             HTTPMethod.PUT, f"teams/{team_inserted.id}", auth_context, None, body
         )
-        assert response == {'detail': 'Could not find Player(s) with ID {-1}'}
+        assert response == {"detail": "Could not find Player(s) with ID {-1}"}


### PR DESCRIPTION
Handles a security vulnerability where it's possible to link to columns of other tournaments, such as add players from another tournament to a team