### PR TITLE
Stamp alembic head when recreating tables

### DIFF
--- a/backend/bracket/utils/alembic.py
+++ b/backend/bracket/utils/alembic.py
@@ -1,7 +1,6 @@
-from bracket.utils.logging import logger
-
 from alembic import command
 from alembic.config import Config
+from bracket.utils.logging import logger
 
 
 def get_alembic_config() -> None:

--- a/backend/bracket/utils/alembic.py
+++ b/backend/bracket/utils/alembic.py
@@ -1,0 +1,18 @@
+from bracket.utils.logging import logger
+
+from alembic import command
+from alembic.config import Config
+
+
+def get_alembic_config() -> None:
+    return Config("alembic.ini")
+
+
+def alembic_run_migrations() -> None:
+    logger.info("Running migrations")
+    command.upgrade(Config("alembic.ini"), "head")
+
+
+def alembic_stamp_head() -> None:
+    logger.info("Overwriting current version to be the latest revision (head)")
+    command.stamp(Config("alembic.ini"), "head")

--- a/backend/bracket/utils/alembic.py
+++ b/backend/bracket/utils/alembic.py
@@ -3,15 +3,15 @@ from alembic.config import Config
 from bracket.utils.logging import logger
 
 
-def get_alembic_config() -> None:
+def get_alembic_config() -> Config:
     return Config("alembic.ini")
 
 
 def alembic_run_migrations() -> None:
     logger.info("Running migrations")
-    command.upgrade(Config("alembic.ini"), "head")
+    command.upgrade(get_alembic_config(), "head")
 
 
 def alembic_stamp_head() -> None:
     logger.info("Overwriting current version to be the latest revision (head)")
-    command.stamp(Config("alembic.ini"), "head")
+    command.stamp(get_alembic_config(), "head")

--- a/backend/bracket/utils/db_init.py
+++ b/backend/bracket/utils/db_init.py
@@ -44,6 +44,7 @@ from bracket.sql.stage_items import sql_create_stage_item
 from bracket.sql.stages import get_full_tournament_details
 from bracket.sql.tournaments import sql_get_tournament
 from bracket.sql.users import create_user, get_user
+from bracket.utils.alembic import alembic_stamp_head
 from bracket.utils.db import insert_generic
 from bracket.utils.dummy_records import (
     DUMMY_CLUB,
@@ -116,6 +117,7 @@ async def init_db_when_empty() -> UserId | None:
         ):
             logger.warning("Empty db detected, creating tables...")
             metadata.create_all(engine)
+            alembic_stamp_head()
 
             logger.warning("Empty db detected, creating admin user...")
             return await create_admin_user()
@@ -133,6 +135,7 @@ async def sql_create_dev_db() -> UserId:
     metadata.drop_all(engine)
     metadata.create_all(engine)
     real_user_id = await init_db_when_empty()
+    alembic_stamp_head()
 
     table_lookup: dict[type, Table] = {
         User: users,


### PR DESCRIPTION
fix https://github.com/evroon/bracket/issues/520

After initializing the database, we don't want/need to run any migrations, so we just tell alembic we're on the latest revision.