### PR TITLE
Add multi-architecture build support to GitHub Actions

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -29,6 +29,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Extract metadata (tags, labels) for frontend Docker image
         id: meta_frontend
         uses: docker/metadata-action@dbef88086f6cef02e264edb7dbf63250c17cef6c
@@ -49,6 +52,7 @@ jobs:
           file: frontend/Dockerfile
           tags: ${{ steps.meta_frontend.outputs.tags }}
           labels: ${{ steps.meta_frontend.outputs.labels }}
+          platforms: linux/amd64,linux/arm64/v8
 
       - name: Build and push backend Docker image
         uses: docker/build-push-action@1ca370b3a9802c92e886402e0dd88098a2533b12
@@ -58,3 +62,4 @@ jobs:
           file: backend/Dockerfile
           tags: ${{ steps.meta_backend.outputs.tags }}
           labels: ${{ steps.meta_backend.outputs.labels }}
+          platforms: linux/amd64,linux/arm64/v8


### PR DESCRIPTION
Extend the Docker publishing workflow to build and push images for both amd64 and arm64 architectures using Docker Buildx.