### PR TITLE
fix: publish docker image workflow

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -22,15 +22,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Log in to the Container registry
         uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
 
       - name: Extract metadata (tags, labels) for frontend Docker image
         id: meta_frontend
@@ -52,7 +55,7 @@ jobs:
           file: frontend/Dockerfile
           tags: ${{ steps.meta_frontend.outputs.tags }}
           labels: ${{ steps.meta_frontend.outputs.labels }}
-          platforms: linux/amd64,linux/arm64/v8
+          platforms: linux/amd64
 
       - name: Build and push backend Docker image
         uses: docker/build-push-action@1ca370b3a9802c92e886402e0dd88098a2533b12

--- a/README.md
+++ b/README.md
@@ -150,6 +150,13 @@ See the [contribution docs](https://docs.bracketapp.nl/docs/community/contributi
 <table>
 <tr>
     <td align="center">
+        <a href="https://github.com/BachErik">
+            <img src="https://avatars.githubusercontent.com/u/75324423?v=4" width="100;" alt="BachErik"/>
+            <br />
+            <sub><b>BachErik</b></sub>
+        </a>
+    </td>
+    <td align="center">
         <a href="https://github.com/evroon">
             <img src="https://avatars.githubusercontent.com/u/11857441?v=4" width="100;" alt="evroon"/>
             <br />

--- a/docs/docs/community/contributing.md
+++ b/docs/docs/community/contributing.md
@@ -38,6 +38,13 @@ translation for you, and then carefully check and correct any mistakes.
 <table>
 <tr>
     <td align="center">
+        <a href="https://github.com/BachErik">
+            <img src="https://avatars.githubusercontent.com/u/75324423?v=4" width="100;" alt="BachErik"/>
+            <br />
+            <sub><b>BachErik</b></sub>
+        </a>
+    </td>
+    <td align="center">
         <a href="https://github.com/evroon">
             <img src="https://avatars.githubusercontent.com/u/11857441?v=4" width="100;" alt="evroon"/>
             <br />


### PR DESCRIPTION
After many tests, I have now discovered that there is currently a problem with node and arm64 in GitHub workflows. There is the following issue: https://github.com/nodejs/docker-node/issues/1335. As already mentioned at the top of the Node.js issue, a possible solution would be to run it in offline mode, i.e. to cache the packages.

I have now adapted the GitHub workflow file so that it already works.
As you have already correctly noted, I have added QEMU.

Since this problem only affects Node, the backend is not affected and already has the multi-architecture variant. To give the frontend multi-arch as well, you would only have to add `linux/arm64` to the platform, and then it should also work there.

But I still have a question: Why do you not work with the versions in the workflow file, but with special commits?