### PR TITLE
Fix Team Logos not loading

### DIFF
--- a/frontend/src/components/modals/team_update_modal.tsx
+++ b/frontend/src/components/modals/team_update_modal.tsx
@@ -27,7 +27,7 @@ import { DropzoneButton } from '../utils/file_upload';
 
 function TeamLogo({ team }: { team: TeamInterface | null }) {
   if (team == null || team.logo_path == null) return null;
-  return <Image radius="md" src={`${getBaseApiUrl()}/static/${team.logo_path}`} />;
+  return <Image radius="md" src={`${getBaseApiUrl()}/static/team-logos/${team.logo_path}`} />;
 }
 
 export default function TeamUpdateModal({


### PR DESCRIPTION
Team logos currently do not load because the URL does not reflect the location of team logos. This should fix it  