### PR TITLE
Fix healthcheck commands

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,7 +19,7 @@ RUN set -ex \
 EXPOSE 8400
 
 HEALTHCHECK --interval=15s --timeout=5s --retries=5 \
-    CMD wget --spider http://localhost:8400 || exit 1
+    CMD curl --fail http://localhost:8400 || exit 1
 
 CMD pipenv run gunicorn \
     -k uvicorn.workers.UvicornWorker \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,8 +18,8 @@ RUN set -ex \
 
 EXPOSE 8400
 
-HEALTHCHECK --interval=15s --timeout=5s --retries=5 \
-    CMD curl --fail http://localhost:8400 || exit 1
+HEALTHCHECK --interval=10s --timeout=5s --retries=5 \
+    CMD wget --spider http://0.0.0.0:8400/ping || exit 1
 
 CMD pipenv run gunicorn \
     -k uvicorn.workers.UvicornWorker \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,8 @@ services:
       ENVIRONMENT: DEVELOPMENT
       CORS_ORIGINS: http://localhost:3000
       PG_DSN: postgresql://bracket_dev:bracket_dev@postgres:5432/bracket_dev
-    image: ghcr.io/evroon/bracket-backend
+    build: backend
+#    image: ghcr.io/evroon/bracket-backend
     networks:
       - bracket_lan
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,7 @@ services:
       ENVIRONMENT: DEVELOPMENT
       CORS_ORIGINS: http://localhost:3000
       PG_DSN: postgresql://bracket_dev:bracket_dev@postgres:5432/bracket_dev
-    build: backend
-#    image: ghcr.io/evroon/bracket-backend
+    image: ghcr.io/evroon/bracket-backend
     networks:
       - bracket_lan
     ports:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -51,7 +51,7 @@ EXPOSE 3000
 
 ENTRYPOINT ["/app/entrypoint.sh"]
 
-HEALTHCHECK --interval=15s --timeout=5s --retries=5 \
-    CMD curl --fail http://localhost:3000 || exit 1
+HEALTHCHECK --interval=10s --timeout=5s --retries=5 \
+    CMD wget --spider http://localhost:3000 || exit 1
 
 CMD yarn start

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -52,6 +52,6 @@ EXPOSE 3000
 ENTRYPOINT ["/app/entrypoint.sh"]
 
 HEALTHCHECK --interval=15s --timeout=5s --retries=5 \
-    CMD wget --spider http://localhost:3000 || exit 1
+    CMD curl --fail http://localhost:3000 || exit 1
 
 CMD yarn start


### PR DESCRIPTION
ref https://github.com/evroon/bracket/issues/1150

the backend healthcheck on localhost doesn't work, needs to be `0.0.0.0`:

```
/app $ wget --spider http://localhost:8400/ping
Connecting to localhost:8400 ([::1]:8400)
wget: can't connect to remote host: Connection refused
```