### PR TITLE
add missing locale

### DIFF
--- a/frontend/next-i18next.config.js
+++ b/frontend/next-i18next.config.js
@@ -2,7 +2,7 @@
 const path = require('path');
 module.exports = {
   i18n: {
-    locales: ['en', 'nl', 'de', 'es', 'zh'],
+    locales: ['de', 'el', 'en', 'es', 'fr', 'it', 'ja', 'nl', 'pt', 'sv', 'zh'],
     defaultLocale: 'en',
   },
   localePath: path.resolve('./public/locales')


### PR DESCRIPTION
I was wondering why these locale were not added in the project. Adding them make the language configuration UI works properly with missing languages. Right now, if you set french or italian, it does not work. With this patch, everything works out.