### PR TITLE
Add member names to teams table

### DIFF
--- a/frontend/src/components/info/player_list.tsx
+++ b/frontend/src/components/info/player_list.tsx
@@ -3,5 +3,11 @@ import { Text } from '@mantine/core';
 import { TeamInterface } from '../../interfaces/team';
 
 export default function PlayerList({ team }: { team: TeamInterface }) {
-  return <Text inherit>{team.name}</Text>;
+  const getPlayerNames = () => team.players.map(p => p.name).sort().join(", ") || "-";
+
+  return (
+    <Text lineClamp={1} title={getPlayerNames()}>
+      {getPlayerNames()}
+    </Text>
+  );
 }


### PR DESCRIPTION
Hi there, cool project. I appreciated seeing a working example of FastAPI + NextJS together.

I noticed the teams table didn't show each team member in the members column, so here's a small PR to do so. Feel free to suggest edits!

Screenshot:
![Screenshot 2025-05-05 at 12 24 51 PM](https://github.com/user-attachments/assets/ec9bf320-0423-434f-aee4-12f099d0c70e)
