### PR TITLE
Fix link to config docs from deployment page

### DIFF
--- a/docs/content/deployment/index.mdx
+++ b/docs/content/deployment/index.mdx
@@ -25,7 +25,7 @@ Optional:
 - `SENTRY_DSN`: The [Sentry](https://sentry.io) DSN  for monitoring and error tracking
 - `BASE_URL`: The base url of the API used for SSO
 
-See [the config docs](../running-bracket/configuration.mdx) for more information.
+See [the config docs](/docs/running-bracket/configuration.mdx) for more information.
 
 ### Frontend configuration
 


### PR DESCRIPTION
I noticed another broken link while using the docs.