### PR TITLE
Fix process compose docs cmd and broken link

### DIFF
--- a/docs/content/community/development.mdx
+++ b/docs/content/community/development.mdx
@@ -6,7 +6,7 @@ title: Development
 
 This guide explains how to run Bracket without Docker. They cover database setup, configuration and
 how to run the frontend and backend. If you quickly want to get up and running, please read
-[quickstart](../running-bracket/quickstart.mdx).
+[quickstart](/docs/running-bracket/quickstart.mdx).
 
 ## Database
 
@@ -31,7 +31,7 @@ You can do the same but replace the user and database name with:
 - `bracket_prod`: for a production database
 
 The database URL can be specified per environment in the `.env` files (see
-[config](../running-bracket/configuration.mdx)).
+[config](/docs/running-bracket/configuration.mdx)).
 
 ## Running the frontend and backend
 

--- a/docs/content/deployment/index.mdx
+++ b/docs/content/deployment/index.mdx
@@ -5,7 +5,7 @@ title: Deployment
 # Deployment
 
 The guides in this directory explain how to run Bracket in production. If you quickly want to get up
-and running, please read [quickstart.md](../running-bracket/quickstart.mdx).
+and running, please read [quickstart.md](/docs/running-bracket/quickstart.mdx).
 
 ## Configuration
 

--- a/process-compose-example.yml
+++ b/process-compose-example.yml
@@ -36,7 +36,7 @@ processes:
 
    docs:
     working_dir: "docs"
-    command: "yarn run docusaurus start -p 3001"
+    command: "yarn run dev -p 3001"
     availability:
       restart: "on_failure"
     readiness_probe:


### PR DESCRIPTION
Fix a broken link in `docs/content/deployment/index.mdx`, make all links absolute for clarity and fix the command to start docs in process-compose-example.yml