### PR TITLE
Add boolean match played status; Differentiate between upcoming and p…

### DIFF
--- a/backend/bracket/models/db/match.py
+++ b/backend/bracket/models/db/match.py
@@ -24,6 +24,7 @@ class MatchBaseInsertable(BaseModelORM):
     court_id: CourtId | None = None
     stage_item_input1_conflict: bool
     stage_item_input2_conflict: bool
+    played: bool = False
 
     @property
     def end_time(self) -> datetime_utc:
@@ -60,9 +61,7 @@ class MatchWithDetails(Match):
     court: Court | None = None
 
 
-def get_match_hash(
-    stage_item_input1_id: StageItemInputId | None, stage_item_input2_id: StageItemInputId | None
-) -> str:
+def get_match_hash(stage_item_input1_id: StageItemInputId | None, stage_item_input2_id: StageItemInputId | None) -> str:
     return f"{stage_item_input1_id}-{stage_item_input2_id}"
 
 
@@ -93,6 +92,7 @@ class MatchBody(BaseModelORM):
     court_id: CourtId | None = None
     custom_duration_minutes: int | None = None
     custom_margin_minutes: int | None = None
+    played: bool = False
 
 
 class MatchCreateBodyFrontend(BaseModelORM):

--- a/backend/bracket/schema.py
+++ b/backend/bracket/schema.py
@@ -139,6 +139,7 @@ matches = Table(
     Column("stage_item_input1_score", Integer, nullable=False),
     Column("stage_item_input2_score", Integer, nullable=False),
     Column("position_in_schedule", Integer, nullable=True),
+    Column("played", Boolean, nullable=False),
 )
 
 teams = Table(

--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -272,5 +272,7 @@
     "win_distribution_text_draws": "zeichnet",
     "win_distribution_text_losses": "Niederlagen",
     "win_distribution_text_win": "Siege",
-    "win_points_input_label": "Punkte für einen Sieg"
+    "win_points_input_label": "Punkte für einen Sieg",
+    "results_tab_upcoming": "Bevorstehende Spiele",
+    "results_tab_past": "Vergangene Spiele"
 }

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -272,5 +272,7 @@
     "win_distribution_text_draws": "draws",
     "win_distribution_text_losses": "losses",
     "win_distribution_text_win": "wins",
-    "win_points_input_label": "Points for a win"
+    "win_points_input_label": "Points for a win",
+    "results_tab_upcoming": "Upcoming Matches",
+    "results_tab_past": "Past Matches"
 }

--- a/frontend/src/components/dashboard/layout.tsx
+++ b/frontend/src/components/dashboard/layout.tsx
@@ -86,6 +86,7 @@ export function DoubleHeader({ tournamentData }: { tournamentData: Tournament })
 
   const mainLinks = [
     { link: `/tournaments/${endpoint}/dashboard`, label: 'Matches' },
+    { link: `/tournaments/${endpoint}/dashboard/results`, label: 'Results' },
     { link: `/tournaments/${endpoint}/dashboard/standings`, label: 'Standings' },
   ];
 

--- a/frontend/src/components/modals/match_modal.tsx
+++ b/frontend/src/components/modals/match_modal.tsx
@@ -106,6 +106,7 @@ function MatchModalForm({
             court_id: match.court_id,
             custom_duration_minutes: customDurationEnabled ? values.custom_duration_minutes : null,
             custom_margin_minutes: customMarginEnabled ? values.custom_margin_minutes : null,
+            played: true,
           };
           await updateMatch(tournamentData.id, match.id, updatedMatch);
           await swrStagesResponse.mutate();

--- a/frontend/src/interfaces/match.tsx
+++ b/frontend/src/interfaces/match.tsx
@@ -32,6 +32,7 @@ export interface MatchBodyInterface {
   court_id: number | null;
   custom_duration_minutes: number | null;
   custom_margin_minutes: number | null;
+  played: boolean;
 }
 
 export interface MatchRescheduleInterface {

--- a/frontend/src/pages/tournaments/[id]/dashboard/results.tsx
+++ b/frontend/src/pages/tournaments/[id]/dashboard/results.tsx
@@ -16,6 +16,7 @@ import { formatMatchInput1, formatMatchInput2 } from '../../../../interfaces/mat
 import { getCourtsLive, getStagesLive } from '../../../../services/adapter';
 import { getMatchLookup, getStageItemLookup, stringToColour } from '../../../../services/lookups';
 import { getTournamentResponseByEndpointName } from '../../../../services/tournament';
+import { finished } from 'stream';
 
 function ScheduleRow({
   data,
@@ -45,77 +46,54 @@ function ScheduleRow({
 
   return (
     <Card shadow="sm" radius="md" withBorder mt="md" pt="0rem">
-      <Card.Section withBorder>
-        <Grid pt="0.75rem" pb="0.5rem">
-          <Grid.Col mb="0rem" span={4}>
-            <Text pl="sm" mt="sm" fw={800}>
-              {data.match.court.name}
-            </Text>
-          </Grid.Col>
-          <Grid.Col mb="0rem" span={4}>
-            <Center>
-              <Text mt="sm" fw={800}>
-                {data.match.start_time != null ? <Time datetime={data.match.start_time} /> : null}
+      <Grid pt="0.5rem" pb="0.5rem">
+        <Grid.Col span={6}  pb="0rem">
+          <Grid>
+            <Grid.Col span="auto" pb="0rem">
+              <Text fw={500}>
+                {formatMatchInput1(t, stageItemsLookup, matchesLookup, data.match)}
               </Text>
-            </Center>
-          </Grid.Col>
-          <Grid.Col mb="0rem" span={4}>
-            <Flex justify="right">
-              <Badge
-                color={stringToColour(`${data.stageItem.id}`)}
-                variant="outline"
-                mr="md"
-                mt="0.8rem"
-                size="md"
+            </Grid.Col>
+            <Grid.Col span="content" pb="0rem">
+              <div
+                style={{
+                  backgroundColor: team1_color,
+                  borderRadius: '0.5rem',
+                  width: '2.5rem',
+                  color: 'white',
+                  fontWeight: 800,
+                }}
               >
-                {data.stageItem.name}
-              </Badge>
-            </Flex>
-          </Grid.Col>
-        </Grid>
-      </Card.Section>
-      <Stack pt="sm">
-        <Grid>
-          <Grid.Col span="auto" pb="0rem">
-            <Text fw={500}>
-              {formatMatchInput1(t, stageItemsLookup, matchesLookup, data.match)}
-            </Text>
-          </Grid.Col>
-          <Grid.Col span="content" pb="0rem">
-            <div
-              style={{
-                backgroundColor: team1_color,
-                borderRadius: '0.5rem',
-                width: '2.5rem',
-                color: 'white',
-                fontWeight: 800,
-              }}
-            >
-              <Center>{data.match.stage_item_input1_score}</Center>
-            </div>
-          </Grid.Col>
-        </Grid>
-        <Grid mb="0rem">
-          <Grid.Col span="auto" pb="0rem">
-            <Text fw={500}>
-              {formatMatchInput2(t, stageItemsLookup, matchesLookup, data.match)}
-            </Text>
-          </Grid.Col>
-          <Grid.Col span="content" pb="0rem">
-            <div
-              style={{
-                backgroundColor: team2_color,
-                borderRadius: '0.5rem',
-                width: '2.5rem',
-                color: 'white',
-                fontWeight: 800,
-              }}
-            >
-              <Center>{data.match.stage_item_input2_score}</Center>
-            </div>
-          </Grid.Col>
-        </Grid>
-      </Stack>
+                <Center>{data.match.stage_item_input1_score}</Center>
+                
+              </div>
+            </Grid.Col>
+          </Grid>
+        </Grid.Col>
+        <Grid.Col span={6} pb="0rem">
+          <Grid mb="0rem">
+            <Grid.Col span="auto" pb="0rem">
+              <div
+                style={{
+                  backgroundColor: team2_color,
+                  borderRadius: '0.5rem',
+                  width: '2.5rem',
+                  color: 'white',
+                  fontWeight: 800,
+                }}
+              >
+                <Center>{data.match.stage_item_input2_score}</Center>
+              </div>
+            </Grid.Col>
+            <Grid.Col span="content" pb="0rem">
+              <Text fw={500}>
+                {formatMatchInput2(t, stageItemsLookup, matchesLookup, data.match)}
+              </Text>
+            </Grid.Col>
+            
+          </Grid>
+        </Grid.Col>
+      </Grid>
     </Card>
   );
 }
@@ -132,7 +110,7 @@ export function Schedule({
   const matches: any[] = Object.values(matchesLookup);
   const sortedMatches = matches
     .filter((m1: any) => m1.match.start_time != null)
-    .filter((m1: any) => m1.match.played === false)
+    .filter((m1: any) => m1.match.played)
     .sort(
       (m1: any, m2: any) =>
         compareDateTime(m1.match.start_time, m2.match.start_time) ||
@@ -145,13 +123,13 @@ export function Schedule({
     const data = sortedMatches[c];
 
     rows.push(
-      <ScheduleRow
-        key={data.match.id}
-        data={data}
-        stageItemsLookup={stageItemsLookup}
-        matchesLookup={matchesLookup}
-      />
-    );
+    <ScheduleRow
+      key={data.match.id}
+      data={data}
+      stageItemsLookup={stageItemsLookup}
+      matchesLookup={matchesLookup}
+    />
+  );
   }
 
   if (rows.length < 1) {

--- a/frontend/src/pages/tournaments/[id]/results.tsx
+++ b/frontend/src/pages/tournaments/[id]/results.tsx
@@ -26,6 +26,7 @@ import { MatchInterface, formatMatchInput1, formatMatchInput2 } from '../../../i
 import { getCourts, getStages } from '../../../services/adapter';
 import { getMatchLookup, getStageItemLookup, stringToColour } from '../../../services/lookups';
 import TournamentLayout from '../_tournament_layout';
+import { Tabs } from '@mantine/core';
 
 function ScheduleRow({
   data,
@@ -150,15 +151,18 @@ function Schedule({
   stageItemsLookup,
   openMatchModal,
   matchesLookup,
+  matchPlayedFilter,
 }: {
   t: Translator;
   stageItemsLookup: any;
   openMatchModal: CallableFunction;
   matchesLookup: any;
+  matchPlayedFilter: boolean;
 }) {
   const matches: any[] = Object.values(matchesLookup);
   const sortedMatches = matches
     .filter((m1: any) => m1.match.start_time != null)
+    .filter((m1: any) => m1.match.played === matchPlayedFilter)
     .sort((m1: any, m2: any) => (m1.match.court?.name > m2.match.court?.name ? 1 : -1))
     .sort((m1: any, m2: any) => (m1.match.start_time > m2.match.start_time ? 1 : -1));
 
@@ -225,6 +229,7 @@ function Schedule({
 }
 
 export default function SchedulePage() {
+  const [activeTab, setActiveTab] = useState<string | null>('upcoming');
   const [modalOpened, modalSetOpened] = useState(false);
   const [match, setMatch] = useState<MatchInterface | null>(null);
 
@@ -265,14 +270,36 @@ export default function SchedulePage() {
         round={null}
       />
       <Title>{t('results_title')}</Title>
-      <Center mt="1rem">
-        <Schedule
-          t={t}
-          matchesLookup={matchesLookup}
-          stageItemsLookup={stageItemsLookup}
-          openMatchModal={openMatchModal}
-        />
-      </Center>
+      
+      <Tabs value={activeTab} onChange={setActiveTab} mt="md">
+        <Tabs.List>
+          <Tabs.Tab value="upcoming">{t('results_tab_upcoming')}</Tabs.Tab>
+          <Tabs.Tab value="past">{t('results_tab_past')}</Tabs.Tab>
+        </Tabs.List>
+        <Tabs.Panel value="upcoming" pt="md">
+          <Center mt="1rem">
+            <Schedule
+              t={t}
+              matchesLookup={matchesLookup}
+              stageItemsLookup={stageItemsLookup}
+              openMatchModal={openMatchModal}
+              matchPlayedFilter={false}
+            />
+          </Center>
+        </Tabs.Panel>
+        <Tabs.Panel value="past" pt="md">
+          <Center mt="1rem">
+            <Schedule
+              t={t}
+              matchesLookup={matchesLookup}
+              stageItemsLookup={stageItemsLookup}
+              openMatchModal={openMatchModal}
+              matchPlayedFilter={true}
+            />
+          </Center>
+        </Tabs.Panel>
+      </Tabs>
+
     </TournamentLayout>
   );
 }


### PR DESCRIPTION
Adds a new match attribute called "played" which is a boolean flag, whether a match has been played or not. This helps in differentiating between upcoming and past matches, especially when entering results or viewing the dashboard.

Therefore, I added two different tabs to the dashboard, as well as the results page, to view the upcoming and past matches. This makes entering results way easier and stops heavy scrolling/searching.

I also changed the layout of the new past results in the dashboard. If we want to keep this consistent, I could add a setting that switches between the compact and the extended stage item view. Just let me know. 