### PR TITLE
Fix match sorting algorithm

### DIFF
--- a/backend/bracket/logic/planning/matches.py
+++ b/backend/bracket/logic/planning/matches.py
@@ -62,9 +62,6 @@ async def schedule_all_unscheduled_matches(
                     position_last_match_from_previous_stage = max(
                         position_last_match_from_previous_stage, position_in_schedule)
 
-        stage_start_time = time_last_match_from_previous_stage
-        stage_position_in_schedule = position_last_match_from_previous_stage
-
     await update_start_times_of_matches(tournament_id)
 
 

--- a/backend/bracket/logic/planning/matches.py
+++ b/backend/bracket/logic/planning/matches.py
@@ -57,10 +57,12 @@ async def schedule_all_unscheduled_matches(
                     position_in_schedule += 1
 
                     time_last_match_from_previous_stage = max(
-                        time_last_match_from_previous_stage, start_time)
+                        time_last_match_from_previous_stage, start_time
+                    )
 
                     position_last_match_from_previous_stage = max(
-                        position_last_match_from_previous_stage, position_in_schedule)
+                        position_last_match_from_previous_stage, position_in_schedule
+                    )
 
     await update_start_times_of_matches(tournament_id)
 


### PR DESCRIPTION
This PR alters the match scheduling logic

Now, the algorithm schedules all matches for each stage in sequence (i.e. all matches from stage A, then all matches from stage B). Matches from stage items inside a single stage are interleaved.

To guarantee that the correct order is followed, rounds are sorted according to their id. Lower round id are scheduled first.

Fix #1312