### PR TITLE
Mounting to /var/lib/postgres/data is no longer allowed after Postgres 18

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,4 +36,4 @@ services:
       - bracket_lan
     restart: always
     volumes:
-      - bracket_pg_data:/var/lib/postgresql/data
+      - bracket_pg_data:/var/lib/postgresql


### PR DESCRIPTION
I got an error when running bracket through the provided compose because mounting directly to the postgres data directory is not allowed after version 18