### PR TITLE
Fix provided port in docs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - bracket_lan
     ports:
       - 8400:8400
+      - 3000:3000
     restart: unless-stopped
     volumes:
       - bracket_static_data:/app/static

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,6 @@ services:
       - bracket_lan
     ports:
       - 8400:8400
-      - 3000:3000
     restart: unless-stopped
     volumes:
       - bracket_static_data:/app/static

--- a/docs/content/running-bracket/quickstart.mdx
+++ b/docs/content/running-bracket/quickstart.mdx
@@ -14,7 +14,7 @@ sudo docker compose up -d
 ```
 
 This will start the backend and frontend of Bracket, as well as a postgres instance. You should now
-be able to view bracket at `http://localhost:3000`. You can log in with the following credentials:
+be able to view bracket at `http://localhost:8400`. You can log in with the following credentials:
 
 - Username: `test@example.org`
 - Password: `aeGhoe1ahng2Aezai0Dei6Aih6dieHoo`.


### PR DESCRIPTION
The port in the docker compose seems to be 8400, however the docs say it's 3000. Users may not know why they are seeing Connection refused issues